### PR TITLE
Refactor promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -442,11 +442,6 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "which-webstorm": "index.js"
   },
   "scripts": {
-    "style:check":"prettier --check .",
-    "style:write":"prettier --write .",
+    "style:check": "prettier --check .",
+    "style:write": "prettier --write .",
     "test": "nyc mocha"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "Oliver Salzburg <oliver.salzburg@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.7.2",
     "execa": "^4.0.3",
     "semver": "^7.3.2",
     "which": "^2.0.2"


### PR DESCRIPTION
About removing bluebird…
- `which` already supports using Promises, that is no big deal here
- NodeJS added fs.promises some time ago

Unfortunately the Promise returned by fs.promises does not support chaining array methods as nicely as the bluebird promisifyed version did. That is the cost for losing one dependencies (and its 282 third party dependencies). But the code definitely looks worse than before :-)

Your decision — I won't be sad if you reject the PR… 


